### PR TITLE
Guard against "Unknown option: t_SR" for older Vim

### DIFF
--- a/doc/terminus.txt
+++ b/doc/terminus.txt
@@ -376,6 +376,7 @@ Other contributors that have submitted patches include (in alphabetical
 order):
 
   Jan Christoph Ebersbach
+  Joe Lencioni
 
 
 HISTORY                                                      *terminus-history*
@@ -388,6 +389,8 @@ HISTORY                                                      *terminus-history*
   Ebersbach).
 - Fixed bug where file modelines were being inappropriately evaluated when on
   |FocusGained| and |FocusLost| events.
+- Added guard for "Unknown option: t_SR" for older versions of Vim (patch from
+  Joe Lencioni).
 
 0.2 (24 July 2015)
 

--- a/plugin/terminus.vim
+++ b/plugin/terminus.vim
@@ -55,7 +55,9 @@ if s:shape
   endif
 
   let &t_SI=s:start_insert
-  let &t_SR=s:start_replace
+  if v:version > 704 || v:version == 704 && has('patch687')
+    let &t_SR=s:start_replace
+  end
   let &t_EI=s:end_insert
 endif
 


### PR DESCRIPTION
After updating from 928b3bfb to 10564cb4 I started getting the following
error when starting Vim:

> Error detected while processing
> /path/to/.vim/bundle/terminus/plugin/terminus.vim:
> line   58:
> E355: Unknown option: t_SR

It appears that the t_SR reference was added by 640509f8.

I was running an old version of Vim for some reason (7.4.488) and
upgrading (to 7.4.873) made this message disappear. It looks like `t_SR`
was added in patch 687 [0](https://github.com/vim/vim/releases/tag/v7.4.687), so we can be more hospitable to people who
aren't on the latest by adding a guard for this patch.
