### PR TITLE
Let VIM auto-detect ttymouse when $TERM contains 'xterm'

### DIFF
--- a/plugin/terminus.vim
+++ b/plugin/terminus.vim
@@ -69,8 +69,6 @@ if s:mouse
       if !has('nvim')
         if has('mouse_sgr')
           set ttymouse=sgr
-        else
-          set ttymouse=xterm2
         endif
       endif
     endif


### PR DESCRIPTION
Fix for Issue #13.
