### PR TITLE
Trigger Focus* in vim terminals (+fix scrambled characters)

### DIFF
--- a/autoload/terminus/private.vim
+++ b/autoload/terminus/private.vim
@@ -49,6 +49,24 @@ function! terminus#private#focus_gained() abort
   return l:cmdline
 endfunction
 
+function! terminus#private#term_focus_lost() abort
+  if s:nomodeline
+    silent doautocmd <nomodeline> FocusLost %
+  else
+    silent doautocmd FocusLost %
+  endif
+  return '' " It's executed as a tmap <expr>, so return nothing to type
+endfunction
+
+function! terminus#private#term_focus_gained() abort
+  if s:nomodeline
+    silent! doautocmd <nomodeline> FocusGained %
+  else
+    silent! doautocmd FocusGained %
+  endif
+  return '' " It's executed as a tmap <expr>, so return nothing to type
+endfunction
+
 function! terminus#private#paste(ret) abort
   set paste
   return a:ret

--- a/plugin/terminus.vim
+++ b/plugin/terminus.vim
@@ -121,6 +121,13 @@ if s:focus
     cnoremap <silent> <f20> <c-\>eterminus#private#focus_lost()<cr>
     cnoremap <silent> <f21> <c-\>eterminus#private#focus_gained()<cr>
 
+    if has('terminal')
+      " Trigger FocusLost/Gained autocommands while in terminal (gvim like)
+      " Indirectly fixes scrambled ??? characters in vim terminals
+      tmap <expr> <f20> terminus#private#term_focus_lost()
+      tmap <expr> <f21> terminus#private#term_focus_gained()
+    endif
+
     if v:version > 703 || v:version == 703 && has('patch438')
       " <nomodeline> was added in 7.3.438 (see `:h version7.txt`).
       inoremap <silent> <f20> <c-\><c-o>:silent doautocmd <nomodeline> FocusLost %<cr>


### PR DESCRIPTION
The `FocusLost` and `FocusGained` autocommands aren't executed when in an vim terminal as opposed to gvim. This PR fixes this.

When using vim terminals, I've found out that the focus report feature inputs scrambled characters in a vim terminal. This seems to be caused by vim forwarding `<f20>` and `<f21>` to the terminal. Since this change overwrites the default behaviour, this is indirectly fixed.


Note that it seems that there is some kind of difference between handling autocommands in vim terminals in vim and gvim when using something like `echoerr`: vim doesn't display (but executes since `!echo Hey` works), but gvim displays the error. Not sure if I am doing something wrong here.

Note that the vim terminals itself doesn't get any focus events. I could do a separate PR to do that if this would fit here. (See my branch [add-TerminusFocusTerminalForward](https://github.com/wincent/terminus/compare/master...Neui:add-TerminusFocusTerminalForward))

For reference my versions:  
GNOME Terminal 3.28.2 using VTE 0.52.2 +GNUTLS -PCRE2  
VIM - Vi IMproved 8.1 (2018 May 17, compiled Jun 14 2018 13:19:18)