### PR TITLE
feat: Support blinking cursor via DECSCUSR sequence

### DIFF
--- a/doc/terminus.txt
+++ b/doc/terminus.txt
@@ -103,6 +103,14 @@ OPTIONS                                                      *terminus-options*
 
     let g:TerminusCursorShape=0
 <
+                                                    *g:TerminusCursorBlinking*
+  |g:TerminusCursorBlinking|                               boolean (default: 1)
+
+  Controls whether cursor should blink if supported by the terminal. To
+  disable, set to 0: >
+
+    let g:TerminusCursorBlinking=0
+<
                                                   *g:TerminusInsertCursorShape*
   |g:TerminusInsertCursorShape|                             number (default: 1)
 


### PR DESCRIPTION
Ref: https://www.vt100.net/docs/vt510-rm/DECSCUSR.html

https://github.com/gnachman/iTerm2/pull/92 implemented them for iterm2 as well, but I don't use macOS so cannot test it, would be better if someone can verify and enable it for iterm2.

`DECSCUSR 0` is the same as 1 in official docs, but various terminal emulators changed its semantics to reset to default style:
https://github.com/microsoft/terminal/pull/7379
https://github.com/gnachman/iTerm2/commit/5680f974ab28d436ef29bf562e124fbd3937b96d

Tested with Guake (libvte based), Konsole 20.12.1, and Windows Terminal.