### PR TITLE
Adds iTerm2 to the SGR Protocol supported list

### DIFF
--- a/plugin/terminus.vim
+++ b/plugin/terminus.vim
@@ -79,7 +79,7 @@ let s:mouse=get(g:, 'TerminusMouse', 1)
 if s:mouse
   if has('mouse')
     set mouse=a
-    if s:screenish || s:xterm
+    if s:screenish || s:xterm || s:iterm2
       if !has('nvim')
         if has('mouse_sgr')
           set ttymouse=sgr


### PR DESCRIPTION
Enables proper mouse reporting for large terminal windows.

See that it is supported on the iTerm2 FAQ here: https://iterm2.com/faq.html
I've been using this for a while in my own config, would love to use your plugin also.

Thanks!